### PR TITLE
Fix operator+ and operator- with ints

### DIFF
--- a/TimeSpan.inc
+++ b/TimeSpan.inc
@@ -228,7 +228,7 @@ stock TimeSpan operator+(TimeSpan oper1, TimeSpan oper2)
 
 stock TimeSpan operator+(TimeSpan oper1, int oper2)
 {
-	return new TimeSpan(oper1.TotalSeconds + oper2);
+	return TimeSpan.FromSeconds(oper1.TotalSeconds + oper2);
 }
 
 stock TimeSpan operator-(TimeSpan oper1, TimeSpan oper2)
@@ -238,7 +238,7 @@ stock TimeSpan operator-(TimeSpan oper1, TimeSpan oper2)
 
 stock TimeSpan operator-(TimeSpan oper1, int oper2)
 {
-	return new TimeSpan(oper1.TotalSeconds - oper2);
+	return TimeSpan.FromSeconds(oper1.TotalSeconds - oper2);
 }
 
 stock bool operator<(TimeSpan oper1, TimeSpan oper2)


### PR DESCRIPTION
I stumbled on a bug: if you add integer seconds to a `TimeSpan` it will add these seconds to the days so you get wrong TimeSpan.
Code Snippet to reproduce:
```sourcepawn
// let's assume this is called in OnClientDisconnect
TimeSpan span = g_PlayerTotalTimePlayed[client];
span += RoundToFloor( GetClientTime( client ) );

char buffer[TIMESPAN_LENGTH];
span.ToString( buffer, sizeof buffer, "{Days}d {Hours}h {Minutes}m {Seconds}s" );
PrintToServer( "Updated total time played: %s", buffer );
```
so in this example if `g_PlayerTotalTimePlayed[client]` is `0` and player would be on the server for 5 minutes (`300.0` seconds) then new `span` would be equal to `25920000` (instead of `300`) and it will print `Updated total time played: 300d 0h 0m 0s`.

Another way to fix this is:
```sourcepawn
stock TimeSpan operator+(TimeSpan oper1, int oper2)
{
	return new TimeSpan(.seconds = oper1.TotalSeconds + oper2);
}

stock TimeSpan operator-(TimeSpan oper1, int oper2)
{
	return new TimeSpan(.seconds = oper1.TotalSeconds - oper2);
}
```